### PR TITLE
Exclude tweets same links

### DIFF
--- a/aggregator/src/main/scala/articlestreamer/aggregator/Aggregator.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/Aggregator.scala
@@ -4,6 +4,7 @@ import java.sql.Timestamp
 import java.util.{TimeZone, UUID}
 
 import articlestreamer.aggregator.kafka.scheduled.EndQueueJob
+import articlestreamer.aggregator.redis.RedisClientFactory
 import articlestreamer.aggregator.twitter.TwitterStreamerFactory
 import articlestreamer.aggregator.twitter.utils.TwitterStatusMethods
 import articlestreamer.shared.configuration.ConfigLoader
@@ -24,9 +25,11 @@ class Aggregator(config: ConfigLoader,
                  producer: KafkaProducerWrapper,
                  scheduler: Scheduler,
                  scoreCalculator: TwitterScoreCalculator,
-                 streamer: TwitterStreamerFactory) extends CustomJsonFormats with TwitterStatusMethods with LazyLogging {
+                 streamer: TwitterStreamerFactory,
+                 redisFactory: RedisClientFactory) extends CustomJsonFormats with TwitterStatusMethods with LazyLogging {
 
   val topicManager = new HalfDayTopicManager(config)
+  val redisClient = redisFactory.getClient()
 
   def run() = {
 

--- a/aggregator/src/main/scala/articlestreamer/aggregator/Aggregator.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/Aggregator.scala
@@ -4,7 +4,7 @@ import java.sql.Timestamp
 import java.util.{TimeZone, UUID}
 
 import articlestreamer.aggregator.kafka.scheduled.EndQueueJob
-import articlestreamer.aggregator.redis.RedisClientFactory
+import articlestreamer.aggregator.service.URLStoreService
 import articlestreamer.aggregator.twitter.TwitterStreamerFactory
 import articlestreamer.aggregator.twitter.utils.TwitterStatusMethods
 import articlestreamer.shared.configuration.ConfigLoader
@@ -19,21 +19,16 @@ import org.quartz.CronScheduleBuilder._
 import org.quartz.JobBuilder.newJob
 import org.quartz.TriggerBuilder._
 import org.quartz.{JobDataMap, Scheduler}
-import twitter4j.Status
+import twitter4j.{Status, URLEntity}
 
 class Aggregator(config: ConfigLoader,
                  producer: KafkaProducerWrapper,
                  scheduler: Scheduler,
                  scoreCalculator: TwitterScoreCalculator,
                  streamer: TwitterStreamerFactory,
-                 redisFactory: RedisClientFactory) extends CustomJsonFormats with TwitterStatusMethods with LazyLogging {
+                 urlStore: URLStoreService) extends CustomJsonFormats with TwitterStatusMethods with LazyLogging {
 
   private val topicManager = new HalfDayTopicManager(config)
-  private val redisClient = redisFactory.getClient(config.redisConfig.host, config.redisConfig.port)
-
-  sys.addShutdownHook {
-    redisClient.disconnect
-  }
 
   def run() = {
 
@@ -64,18 +59,43 @@ class Aggregator(config: ConfigLoader,
         logger.warn(s"Tweet ${status.getId} ignored. Reason : 'Retweet' .")
       } else if (!status.containsEnglish) {
         logger.warn(s"Tweet ${status.getId} ignored. Reason : 'Not English' . Content : '${status.getText.mkString}'")
-      } else if (status.getUsableLinks.isEmpty) {
-        logger.warn(s"Tweet ${status.getId} ignored. Reason : 'Not Potential Article' . Content : '${status.getText.mkString}'")
       } else {
-        val article = convertToArticle(status)
+        val usableLinks = status.getUsableLinks
+        if (usableLinks.isEmpty) {
+          logger.warn(s"Tweet ${status.getId} ignored. Reason : 'Not Potential Article' . Content : '${status.getText.mkString}'")
+        } else {
+          val unknwonLinks = findUnknownLinks(usableLinks)
+          if (unknwonLinks.isEmpty) {
+            logger.warn(s"Tweet ${status.getId} ignored. Reason : 'Links all already known' . Links : '${status.getURLEntities.mkString}'")
+          } else {
+            saveNewLinks(unknwonLinks)
 
-        val record = new ProducerRecord[String, String](
-          topicManager.getCurrentTopic(),
-          s"tweet-${status.getId}",
-          write(article))
+            val article = convertToArticle(status)
 
-        producer.send(record)
+            val record = new ProducerRecord[String, String](
+              topicManager.getCurrentTopic(),
+              s"tweet-${status.getId}",
+              write(article))
+
+            producer.send(record)
+          }
+        }
       }
+    }
+  }
+
+  private def saveNewLinks(links: Seq[URLEntity]) = {
+    links.foreach { link =>
+      urlStore.save(link.getExpandedURL)
+    }
+  }
+
+  /**
+    * Check if the provided list contains at least one link unknown by interrogating the Link Storage
+    */
+  private def findUnknownLinks(links: Seq[URLEntity]): Seq[URLEntity] = {
+    links.filterNot { link =>
+      urlStore.exists(link.getExpandedURL)
     }
   }
 

--- a/aggregator/src/main/scala/articlestreamer/aggregator/Aggregator.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/Aggregator.scala
@@ -28,8 +28,10 @@ class Aggregator(config: ConfigLoader,
                  streamer: TwitterStreamerFactory,
                  redisFactory: RedisClientFactory) extends CustomJsonFormats with TwitterStatusMethods with LazyLogging {
 
-  val topicManager = new HalfDayTopicManager(config)
-  val redisClient = redisFactory.getClient()
+  private val topicManager = new HalfDayTopicManager(config)
+  private val redisClient = redisFactory.getClient(config.redisConfig.host, config.redisConfig.port)
+
+  sys.addShutdownHook(redisClient.disconnect)
 
   def run() = {
 

--- a/aggregator/src/main/scala/articlestreamer/aggregator/App.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/App.scala
@@ -1,5 +1,6 @@
 package articlestreamer.aggregator
 
+import articlestreamer.aggregator.redis.DefaultRedisClientFactory
 import articlestreamer.aggregator.twitter.DefaultTwitterStreamerFactory
 import articlestreamer.shared.configuration.DefaultConfigLoader
 import articlestreamer.shared.kafka.{KafkaFactory, KafkaProducerWrapper}
@@ -12,7 +13,7 @@ import twitter4j.TwitterFactory
 /**
   * Created by sam on 15/10/2016.
   */
-object MainApp extends App {
+object App extends App {
 
   lazy val twitterFactory = wire[TwitterFactory]
   lazy val config = wire[DefaultConfigLoader]
@@ -21,6 +22,7 @@ object MainApp extends App {
   lazy val streamFactory = new DefaultTwitterStreamerFactory
   lazy val twitterService = wire[TwitterService]
   lazy val scoreCalculator = wire[NaiveTwitterScoreCalculator]
+  lazy val redisFactory = wire[DefaultRedisClientFactory]
 
   lazy val scheduler = StdSchedulerFactory.getDefaultScheduler
 

--- a/aggregator/src/main/scala/articlestreamer/aggregator/App.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/App.scala
@@ -1,6 +1,7 @@
 package articlestreamer.aggregator
 
 import articlestreamer.aggregator.redis.DefaultRedisClientFactory
+import articlestreamer.aggregator.service.RedisURLStoreService
 import articlestreamer.aggregator.twitter.DefaultTwitterStreamerFactory
 import articlestreamer.shared.configuration.DefaultConfigLoader
 import articlestreamer.shared.kafka.{KafkaFactory, KafkaProducerWrapper}
@@ -23,6 +24,7 @@ object App extends App {
   lazy val twitterService = wire[TwitterService]
   lazy val scoreCalculator = wire[NaiveTwitterScoreCalculator]
   lazy val redisFactory = wire[DefaultRedisClientFactory]
+  lazy val urlStore = wire[RedisURLStoreService]
 
   lazy val scheduler = StdSchedulerFactory.getDefaultScheduler
 

--- a/aggregator/src/main/scala/articlestreamer/aggregator/redis/DefaultRedisClientFactory.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/redis/DefaultRedisClientFactory.scala
@@ -1,0 +1,6 @@
+package articlestreamer.aggregator.redis
+import com.redis.RedisClient
+
+class DefaultRedisClientFactory extends RedisClientFactory {
+  override def getClient(host: String, port: Int): RedisClient = new RedisClient(host, port)
+}

--- a/aggregator/src/main/scala/articlestreamer/aggregator/redis/RedisClientFactory.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/redis/RedisClientFactory.scala
@@ -1,0 +1,9 @@
+package articlestreamer.aggregator.redis
+
+import com.redis.RedisClient
+
+trait RedisClientFactory {
+
+  def getClient(host: String, port: Int): RedisClient
+
+}

--- a/aggregator/src/main/scala/articlestreamer/aggregator/service/RedisURLStoreService.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/service/RedisURLStoreService.scala
@@ -1,0 +1,29 @@
+package articlestreamer.aggregator.service
+
+import articlestreamer.aggregator.redis.RedisClientFactory
+import articlestreamer.shared.configuration.ConfigLoader
+import com.redis.Seconds
+
+/**
+  * Uses Redis as URL Store
+  */
+class RedisURLStoreService(config: ConfigLoader, factory: RedisClientFactory) extends URLStoreService {
+
+  private val redisClient = factory.getClient(config.redisConfig.host, config.redisConfig.port)
+
+  sys.addShutdownHook {
+    redisClient.disconnect
+  }
+
+  override def exists(url: String): Boolean = {
+    redisClient.get[String](url).isDefined
+  }
+
+  /**
+    * Save a new URL in the store
+    */
+  override def save(url: String): Unit = {
+    redisClient.set(url, "", onlyIfExists = false, Seconds(config.redisConfig.expiryTime))
+  }
+
+}

--- a/aggregator/src/main/scala/articlestreamer/aggregator/service/RedisURLStoreService.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/service/RedisURLStoreService.scala
@@ -3,11 +3,12 @@ package articlestreamer.aggregator.service
 import articlestreamer.aggregator.redis.RedisClientFactory
 import articlestreamer.shared.configuration.ConfigLoader
 import com.redis.Seconds
+import com.typesafe.scalalogging.LazyLogging
 
 /**
   * Uses Redis as URL Store
   */
-class RedisURLStoreService(config: ConfigLoader, factory: RedisClientFactory) extends URLStoreService {
+class RedisURLStoreService(config: ConfigLoader, factory: RedisClientFactory) extends URLStoreService with LazyLogging {
 
   private val redisClient = factory.getClient(config.redisConfig.host, config.redisConfig.port)
 
@@ -23,7 +24,12 @@ class RedisURLStoreService(config: ConfigLoader, factory: RedisClientFactory) ex
     * Save a new URL in the store
     */
   override def save(url: String): Unit = {
-    redisClient.set(url, "", onlyIfExists = false, Seconds(config.redisConfig.expiryTime))
+    val result = redisClient.set(url, "", onlyIfExists = false, Seconds(config.redisConfig.expiryTime))
+    if (result) {
+      logger.info(s"Redis: successfully saved url [$url]")
+    } else {
+      logger.error(s"Redis: failed to save url [$url]")
+    }
   }
 
 }

--- a/aggregator/src/main/scala/articlestreamer/aggregator/service/URLStoreService.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/service/URLStoreService.scala
@@ -1,0 +1,18 @@
+package articlestreamer.aggregator.service
+
+/**
+  * Handle the store containing the URLs temporarily stored
+  */
+trait URLStoreService {
+
+  /**
+    * Returns True if the provided URL already exists in the store
+    */
+  def exists(url: String): Boolean
+
+  /**
+    * Save a new URL in the store
+    */
+  def save(url: String): Unit
+
+}

--- a/aggregator/src/main/scala/articlestreamer/aggregator/twitter/utils/TwitterStatusMethods.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/twitter/utils/TwitterStatusMethods.scala
@@ -1,6 +1,6 @@
 package articlestreamer.aggregator.twitter.utils
 
-import twitter4j.Status
+import twitter4j.{Status, URLEntity}
 
 /**
   * Created by sam on 08/11/2016.
@@ -13,17 +13,21 @@ trait TwitterStatusMethods extends URLEntitiesMethods {
       status.getLang == "en"
     }
 
-    def isPotentialArticle: Boolean = {
+    /**
+      * Identify all links in this Status that could be links to articles.
+      * This excludes any social network link as well as media urls.
+      */
+    def getUsableLinks: Array[URLEntity] = {
 
       val links = status.getURLEntities
 
       // An article must contain at least one link
       if (links.length <= 0) {
-        return false
+        return Array()
       }
 
       // At least one of those links isn't a media
-      !links.forall(link => link.isMediaUrl || link.isSocialNetworkURL)
+      links.filterNot(link => link.isMediaUrl || link.isSocialNetworkURL)
     }
 
   }

--- a/aggregator/src/main/scala/articlestreamer/aggregator/twitter/utils/URLEntitiesMethods.scala
+++ b/aggregator/src/main/scala/articlestreamer/aggregator/twitter/utils/URLEntitiesMethods.scala
@@ -6,7 +6,7 @@ trait URLEntitiesMethods {
 
   val imgTypes = Array(".bmp", ".gif", ".img", ".jbg", ".jpe", ".jpeg", ".jpg", ".png", ".ppm", ".tiff")
   val videoTypes = Array(".avi", ".flv", ".mpg", ".mp2", ".mpeg", ".mpe", ".mpv", ".mov", ".mp4")
-  val socialNetworks = Array("www.instagram", "www.facebook", "www.flickr")
+  val socialNetworks = Array("www.instagram", "www.facebook", "www.flickr", "twitter")
 
   implicit class URLEntitiesUtils(urlEntity: URLEntity) {
 

--- a/aggregator/src/test/scala/articlestreamer/aggregator/AggregatorSpec.scala
+++ b/aggregator/src/test/scala/articlestreamer/aggregator/AggregatorSpec.scala
@@ -3,6 +3,7 @@ package articlestreamer.aggregator
 import java.text.SimpleDateFormat
 import java.util.TimeZone
 
+import articlestreamer.aggregator.redis.RedisClientFactory
 import articlestreamer.aggregator.twitter.{DefaultTwitterStreamerFactory, TwitterStreamer}
 import articlestreamer.shared.BaseSpec
 import articlestreamer.shared.configuration.ConfigLoader
@@ -34,6 +35,7 @@ class AggregatorSpec extends BaseSpec with BeforeAndAfter with CustomJsonFormats
   var scoreCalculator: TwitterScoreCalculator = _
   var streamer: TwitterStreamer = _
   var scheduler: Scheduler = _
+  var redisFactory: RedisClientFactory = _
 
   before {
     kafkaWrapper = mock(classOf[KafkaProducerWrapper])
@@ -50,7 +52,7 @@ class AggregatorSpec extends BaseSpec with BeforeAndAfter with CustomJsonFormats
     val factory = mock(classOf[DefaultTwitterStreamerFactory])
     when(factory.getStreamer(any(), any(), any())).thenReturn(streamer)
 
-    val aggregator = new Aggregator(config, kafkaWrapper, scheduler, scoreCalculator, factory)
+    val aggregator = new Aggregator(config, kafkaWrapper, scheduler, scoreCalculator, factory, redisFactory)
     aggregator.run()
 
     verify(streamer, times(1)).startStreaming()
@@ -169,7 +171,7 @@ class AggregatorSpec extends BaseSpec with BeforeAndAfter with CustomJsonFormats
     val factory = mock(classOf[DefaultTwitterStreamerFactory])
     when(factory.getStreamer(any(), captor.capture(), any())).thenReturn(streamer)
 
-    val aggregator = new Aggregator(config, kafkaWrapper, scheduler, scoreCalculator, factory)
+    val aggregator = new Aggregator(config, kafkaWrapper, scheduler, scoreCalculator, factory, redisFactory)
     aggregator.run()
     captor.getValue()
   }

--- a/aggregator/src/test/scala/articlestreamer/aggregator/AggregatorSpec.scala
+++ b/aggregator/src/test/scala/articlestreamer/aggregator/AggregatorSpec.scala
@@ -42,6 +42,7 @@ class AggregatorSpec extends BaseSpec with BeforeAndAfter with CustomJsonFormats
     scoreCalculator = mock(classOf[TwitterScoreCalculator])
     streamer = mock(classOf[TwitterStreamer])
     scheduler = StdSchedulerFactory.getDefaultScheduler
+    redisFactory = mock(classOf[RedisClientFactory])
   }
 
   after {

--- a/aggregator/src/test/scala/articlestreamer/aggregator/AggregatorSpec.scala
+++ b/aggregator/src/test/scala/articlestreamer/aggregator/AggregatorSpec.scala
@@ -4,6 +4,7 @@ import java.text.SimpleDateFormat
 import java.util.TimeZone
 
 import articlestreamer.aggregator.redis.RedisClientFactory
+import articlestreamer.aggregator.service.URLStoreService
 import articlestreamer.aggregator.twitter.{DefaultTwitterStreamerFactory, TwitterStreamer}
 import articlestreamer.shared.BaseSpec
 import articlestreamer.shared.configuration.ConfigLoader
@@ -35,14 +36,14 @@ class AggregatorSpec extends BaseSpec with BeforeAndAfter with CustomJsonFormats
   var scoreCalculator: TwitterScoreCalculator = _
   var streamer: TwitterStreamer = _
   var scheduler: Scheduler = _
-  var redisFactory: RedisClientFactory = _
+  var urlStore: URLStoreService = _
 
   before {
     kafkaWrapper = mock(classOf[KafkaProducerWrapper])
     scoreCalculator = mock(classOf[TwitterScoreCalculator])
     streamer = mock(classOf[TwitterStreamer])
     scheduler = StdSchedulerFactory.getDefaultScheduler
-    redisFactory = mock(classOf[RedisClientFactory])
+    urlStore = mock(classOf[URLStoreService])
   }
 
   after {
@@ -53,7 +54,7 @@ class AggregatorSpec extends BaseSpec with BeforeAndAfter with CustomJsonFormats
     val factory = mock(classOf[DefaultTwitterStreamerFactory])
     when(factory.getStreamer(any(), any(), any())).thenReturn(streamer)
 
-    val aggregator = new Aggregator(config, kafkaWrapper, scheduler, scoreCalculator, factory, redisFactory)
+    val aggregator = new Aggregator(config, kafkaWrapper, scheduler, scoreCalculator, factory, urlStore)
     aggregator.run()
 
     verify(streamer, times(1)).startStreaming()
@@ -172,7 +173,7 @@ class AggregatorSpec extends BaseSpec with BeforeAndAfter with CustomJsonFormats
     val factory = mock(classOf[DefaultTwitterStreamerFactory])
     when(factory.getStreamer(any(), captor.capture(), any())).thenReturn(streamer)
 
-    val aggregator = new Aggregator(config, kafkaWrapper, scheduler, scoreCalculator, factory, redisFactory)
+    val aggregator = new Aggregator(config, kafkaWrapper, scheduler, scoreCalculator, factory, urlStore)
     aggregator.run()
     captor.getValue()
   }

--- a/aggregator/src/test/scala/articlestreamer/aggregator/service/RedisURLStoreServiceSpec.scala
+++ b/aggregator/src/test/scala/articlestreamer/aggregator/service/RedisURLStoreServiceSpec.scala
@@ -1,0 +1,71 @@
+package articlestreamer.aggregator.service
+
+import articlestreamer.aggregator.redis.RedisClientFactory
+import articlestreamer.shared.BaseSpec
+import articlestreamer.shared.configuration.ConfigLoader
+import com.redis.{RedisClient, SecondsOrMillis}
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfter
+
+class RedisURLStoreServiceSpec extends BaseSpec with BeforeAndAfter {
+
+  class TestConfig extends ConfigLoader
+
+  var factory: RedisClientFactory = _
+
+  before {
+    factory = mock(classOf[RedisClientFactory])
+  }
+
+  "Store Service" should "find a URL as key from Redis" in {
+    val client = mock(classOf[RedisClient])
+    when(client.get("http://url")).thenReturn(Some(""))
+    when(factory.getClient(any(), any())).thenReturn(client)
+
+    val storeService = new RedisURLStoreService(new TestConfig, factory)
+    val result = storeService.exists("http://url")
+
+    result shouldBe true
+    verify(client, times(1)).get("http://url")
+  }
+
+  "Store Service" should "not find an unknown URL in Redis" in {
+    val client = mock(classOf[RedisClient])
+    when(client.get("http://url")).thenReturn(None)
+    when(factory.getClient(any(), any())).thenReturn(client)
+
+    val storeService = new RedisURLStoreService(new TestConfig, factory)
+    val result = storeService.exists("http://url")
+
+    result shouldBe false
+    verify(client, times(1)).get("http://url")
+  }
+
+  it should "save a new URL into Redis" in {
+    val client = mock(classOf[RedisClient])
+    when(client.set(ArgumentMatchers.eq("http://url"), ArgumentMatchers.eq(""),
+      ArgumentMatchers.eq(false), any[SecondsOrMillis]())).thenReturn(true)
+    when(factory.getClient(any(), any())).thenReturn(client)
+
+    val storeService = new RedisURLStoreService(new TestConfig, factory)
+    storeService.save("http://url")
+
+    verify(client, times(1)).set(any(), any(), any(), any())
+  }
+
+  // Coverage purposes
+  it should "fail to save a new URL into Redis" in {
+    val client = mock(classOf[RedisClient])
+    when(client.set(ArgumentMatchers.eq("http://url"), ArgumentMatchers.eq(""),
+      ArgumentMatchers.eq(false), any[SecondsOrMillis]())).thenReturn(false)
+    when(factory.getClient(any(), any())).thenReturn(client)
+
+    val storeService = new RedisURLStoreService(new TestConfig, factory)
+    storeService.save("http://url")
+
+    verify(client, times(1)).set(any(), any(), any(), any())
+  }
+
+}

--- a/aggregator/src/test/scala/articlestreamer/aggregator/twitter/utils/TwitterStatusMethodSpec.scala
+++ b/aggregator/src/test/scala/articlestreamer/aggregator/twitter/utils/TwitterStatusMethodSpec.scala
@@ -20,7 +20,7 @@ class TwitterStatusMethodSpec extends BaseSpec with TwitterStatusMethods {
     status.containsEnglish shouldBe false
   }
 
-  "Status with at least one page url" should "be identified as a potential article" in {
+  "Status with a page url" should "return a single URL" in {
     val urlPage = buildEntity("http://thenextweb.com/e-dash-display")
     val urlImg = buildEntity("https://pbs.twimg.com/1234.jpeg")
     val facebookUrl = buildEntity("https://www.facebook.com/62648/photos/352127.62868648/1222842638/?type=3&theater")
@@ -30,20 +30,20 @@ class TwitterStatusMethodSpec extends BaseSpec with TwitterStatusMethods {
     val status = mock(classOf[Status])
     when(status.getURLEntities).thenReturn(urls)
 
-    status.isPotentialArticle shouldBe true
+    status.getUsableLinks shouldBe Array(urlPage)
   }
 
-  "Status with only a page url" should "be identified as a potential article" in {
+  "Status with only a page url" should "return a single URL" in {
     val urlPage = buildEntity("http://thenextweb.com/e-dash-display")
     val urls = Array(urlPage)
 
     val status = mock(classOf[Status])
     when(status.getURLEntities).thenReturn(urls)
 
-    status.isPotentialArticle shouldBe true
+    status.getUsableLinks shouldBe Array(urlPage)
   }
 
-  "Status with only media urls" should "be rejected" in {
+  "Status with only media urls" should "return an empty list" in {
     val urlImg = buildEntity("https://pbs.twimg.com/1234.jpeg")
     val urlVideo = buildEntity("https://pbs.twimg.com/34567.mov")
     val urls = Array(urlVideo, urlImg)
@@ -51,10 +51,10 @@ class TwitterStatusMethodSpec extends BaseSpec with TwitterStatusMethods {
     val status = mock(classOf[Status])
     when(status.getURLEntities).thenReturn(urls)
 
-    status.isPotentialArticle shouldBe false
+    status.getUsableLinks shouldBe empty
   }
 
-  "Status with only social networks urls" should "be rejected" in {
+  "Status with only social networks urls" should "return empty list" in {
     val facebookUrl = buildEntity("https://www.facebook.com/62648/photos/352127.62868648/1222842638/?type=3&theater")
     val instagramUrl = buildEntity("https://www.instagram.com/?hl=en")
     val urls = Array(instagramUrl, facebookUrl)
@@ -62,13 +62,13 @@ class TwitterStatusMethodSpec extends BaseSpec with TwitterStatusMethods {
     val status = mock(classOf[Status])
     when(status.getURLEntities).thenReturn(urls)
 
-    status.isPotentialArticle shouldBe false
+    status.getUsableLinks shouldBe empty
   }
 
-  "Status with no urls" should "be rejected" in {
+  "Status with no urls" should "return empty list" in {
     val status = mock(classOf[Status])
     when(status.getURLEntities).thenReturn(Array[URLEntity]())
-    status.isPotentialArticle shouldBe false
+    status.getUsableLinks shouldBe empty
   }
 
   private def buildEntity(url: String): URLEntity = {

--- a/build.sbt
+++ b/build.sbt
@@ -24,37 +24,35 @@ addCommandAlias("test-shared", ";project shared;clean;coverage;test;coverageRepo
 addCommandAlias("test-all", ";test-agg;test-score;test-proc;test-shared")
 
 //noinspection ScalaUnnecessaryParentheses
-lazy val root = (project in file(".")).
-  settings(Commons.settings: _*).
-  settings(
-    name := "article-streamer",
-
-    // Necessary for using
-    parallelExecution in Test := false,
-
-    // sbt-assembly for FatJar generation
-    mainClass in assembly <<= (mainClass in assembly in aggregator),
-
-    // sbt run by default starts the Aggregator
-    run in Compile <<= (run in Compile in aggregator),
-    packageBin in Compile <<= (packageBin in Compile in aggregator),
-
-    // Heroku configuration
-    herokuAppName in Compile := "article-streamer-aggregator",
-    herokuFatJar in Compile := Some((assemblyOutputPath in assembly).value),
-    herokuProcessTypes in Compile := Map(
-      "worker" -> "java -jar target/scala-2.11/article-streamer-assembly-0.0.1.jar")
-
-  ) dependsOn (aggregator % "test->test;compile->compile") aggregate(aggregator)
+//lazy val root = (project in file(".")).
+//  settings(Commons.settings: _*).
+//  settings(
+//    name := "article-streamer",
+//
+//    // Necessary for using
+//    parallelExecution in Test := false,
+//
+//    // sbt-assembly for FatJar generation
+//    mainClass in assembly <<= (mainClass in assembly in aggregator),
+//
+//    // sbt run by default starts the Aggregator
+//    run in Compile <<= (run in Compile in aggregator),
+//    packageBin in Compile <<= (packageBin in Compile in aggregator),
+//
+//    // Heroku configuration
+//    herokuAppName in Compile := "article-streamer-aggregator",
+//    herokuFatJar in Compile := Some((assemblyOutputPath in assembly).value),
+//    herokuProcessTypes in Compile := Map(
+//      "worker" -> "java -jar target/scala-2.11/article-streamer-assembly-0.0.1.jar")
+//
+//  ) dependsOn (aggregator % "test->test;compile->compile") aggregate(aggregator)
 
 lazy val aggregator = (project in file("aggregator")).
   settings(Commons.settings: _*).
   settings(
     name := "aggregator",
 
-    mainClass in (Compile, run) := Commons.producerMainClass,
-    mainClass in (Compile, packageBin) := Commons.producerMainClass,
-    mainClass in assembly := Commons.producerMainClass,
+    mainClass in assembly := Some("articlestreamer.aggregator.App"),
 
     assemblyOutputPath in assembly := file(s"./aggregator/docker/aggregator-assembly-${version.value}.jar"),
     assemblyMergeStrategy in assembly := {

--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,7 @@ lazy val aggregator = (project in file("aggregator")).
     libraryDependencies += "org.apache.kafka" % "kafka-clients"     % Dependencies.kafkaClientVersion,
     libraryDependencies += "org.twitter4j"    % "twitter4j-stream"  % Dependencies.twitter4JVersion,
     libraryDependencies += "org.quartz-scheduler" % "quartz" % "2.2.1",
+    libraryDependencies += "net.debasishg" %% "redisclient" % "3.2",
 
     coverageExcludedPackages := ".*BasicConsumer;.*MainApp;.*DefaultTwitterStreamer"
 

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val aggregator = (project in file("aggregator")).
     libraryDependencies += "org.quartz-scheduler" % "quartz" % "2.2.1",
     libraryDependencies += "net.debasishg" %% "redisclient" % "3.2",
 
-    coverageExcludedPackages := ".*RedisClientFactory;.*BasicConsumer;.*MainApp;.*DefaultTwitterStreamer"
+    coverageExcludedPackages := ".*RedisClientFactory;.*BasicConsumer;.*App;.*DefaultTwitterStreamer"
 
   ) dependsOn (shared % "test->test;compile->compile")
 

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val aggregator = (project in file("aggregator")).
     libraryDependencies += "org.quartz-scheduler" % "quartz" % "2.2.1",
     libraryDependencies += "net.debasishg" %% "redisclient" % "3.2",
 
-    coverageExcludedPackages := ".*BasicConsumer;.*MainApp;.*DefaultTwitterStreamer"
+    coverageExcludedPackages := ".*RedisClientFactory;.*BasicConsumer;.*MainApp;.*DefaultTwitterStreamer"
 
   ) dependsOn (shared % "test->test;compile->compile")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     env_file: ./aggregator/docker-env.list
     environment:
       KAFKA_BROKERS: kafka:9092
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
     depends_on:
       - kafka
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       KAFKA_BROKERS: kafka:9092
     depends_on:
       - kafka
+      - redis
 
   score_updater:
     container_name: score_updater

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -6,9 +6,6 @@ object Commons {
   val appVersion = "0.0.1"
   val scalaV = "2.11.8"
 
-  // Used as main class for the whole project
-  val producerMainClass = Some("articlestreamer.aggregator.MainApp")
-
   val settings: Seq[Def.Setting[_]] = Seq(
     version := appVersion,
     scalaVersion := scalaV,

--- a/shared/src/main/resources/application.conf
+++ b/shared/src/main/resources/application.conf
@@ -84,3 +84,12 @@ mysql {
   driver = "com.mysql.jdbc.Driver"
 
 }
+
+redis {
+
+  host: "localhost"
+  host: ${REDIS_HOST}
+
+  port: 6379
+  port: ${REDIS_PORT}
+}

--- a/shared/src/main/resources/application.conf
+++ b/shared/src/main/resources/application.conf
@@ -93,4 +93,8 @@ redis {
   port: 6379
   port: ${?REDIS_PORT}
 
+  // Time before a record expire in Seconds. Default is 7 days.
+  expiryTime: 604800
+  port: ${?REDIS_EXPIRE}
+
 }

--- a/shared/src/main/resources/application.conf
+++ b/shared/src/main/resources/application.conf
@@ -88,8 +88,9 @@ mysql {
 redis {
 
   host: "localhost"
-  host: ${REDIS_HOST}
+  host: ${?REDIS_HOST}
 
   port: 6379
-  port: ${REDIS_PORT}
+  port: ${?REDIS_PORT}
+
 }

--- a/shared/src/main/scala/articlestreamer/shared/configuration/ConfigLoader.scala
+++ b/shared/src/main/scala/articlestreamer/shared/configuration/ConfigLoader.scala
@@ -19,6 +19,8 @@ final case class TwitterSearchConfig(mainTag: String,
 
 final case class MysqlConfig(jdbcUrl: String, user: String, password: String, driver: String)
 
+final case class RedisConfig(host: String, port: Int)
+
 trait ConfigLoader extends LazyLogging with Serializable {
 
   val appConfig = ConfigFactory.load()
@@ -46,6 +48,11 @@ trait ConfigLoader extends LazyLogging with Serializable {
     appConfig.getString("mysql.user"),
     appConfig.getString("mysql.password"),
     appConfig.getString("mysql.driver")
+  )
+
+  val redisConfig = RedisConfig(
+    appConfig.getString("redis.host"),
+    appConfig.getInt("redis.port")
   )
 
   /**

--- a/shared/src/main/scala/articlestreamer/shared/configuration/ConfigLoader.scala
+++ b/shared/src/main/scala/articlestreamer/shared/configuration/ConfigLoader.scala
@@ -19,7 +19,7 @@ final case class TwitterSearchConfig(mainTag: String,
 
 final case class MysqlConfig(jdbcUrl: String, user: String, password: String, driver: String)
 
-final case class RedisConfig(host: String, port: Int)
+final case class RedisConfig(host: String, port: Int, expiryTime: Long)
 
 trait ConfigLoader extends LazyLogging with Serializable {
 
@@ -52,7 +52,8 @@ trait ConfigLoader extends LazyLogging with Serializable {
 
   val redisConfig = RedisConfig(
     appConfig.getString("redis.host"),
-    appConfig.getInt("redis.port")
+    appConfig.getInt("redis.port"),
+    appConfig.getInt("redis.expiryTime")
   )
 
   /**

--- a/shared/src/main/scala/articlestreamer/shared/configuration/ConfigLoader.scala
+++ b/shared/src/main/scala/articlestreamer/shared/configuration/ConfigLoader.scala
@@ -53,7 +53,7 @@ trait ConfigLoader extends LazyLogging with Serializable {
   val redisConfig = RedisConfig(
     appConfig.getString("redis.host"),
     appConfig.getInt("redis.port"),
-    appConfig.getInt("redis.expiryTime")
+    appConfig.getLong("redis.expiryTime")
   )
 
   /**


### PR DESCRIPTION
Use Redis as a Link Store to exclude links with already known URLs. The links are kept for 7 days by default.